### PR TITLE
Resolved SSL Verification Error During the WP Remote Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Accept payment using Billplz.
 Compatible up to:
 - PHP 8.1
 - Wordpress 6.3
-- Woocommerce 8.0.2
+- Woocommerce 8.2.1
 
 # Installation
 

--- a/billplzWoo.php
+++ b/billplzWoo.php
@@ -6,7 +6,7 @@
  * Description: Billplz. Fair payment platform.
  * Author: Billplz Sdn Bhd
  * Author URI: http://github.com/billplz/billplz-for-woocommerce
- * Version: 3.28.0
+ * Version: 3.28.1
  * Requires PHP: 7.0
  * Requires at least: 4.6
  * License: GPLv3
@@ -50,7 +50,7 @@ class Woocommerce_Billplz {
     $this->define( 'BFW_PLUGIN_URL', plugin_dir_url(BFW_PLUGIN_FILE));
     $this->define( 'BFW_PLUGIN_DIR',  dirname(BFW_PLUGIN_FILE) );
     $this->define( 'BFW_BASENAME',  plugin_basename(BFW_PLUGIN_FILE) );
-    $this->define( 'BFW_PLUGIN_VER',  '3.28.0' );
+    $this->define( 'BFW_PLUGIN_VER',  '3.28.1' );
   }
 
   public function check_environment() {

--- a/includes/helpers/billplz_wpconnect.php
+++ b/includes/helpers/billplz_wpconnect.php
@@ -55,7 +55,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v4/webhook_rank';
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['method'] = 'GET';
         $response = \wp_remote_post($url, $wp_remote_data);
@@ -69,7 +68,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v4/collections?' . http_build_query($parameter);
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['method'] = 'GET';
 
@@ -103,7 +101,6 @@ class BillplzWooCommerceWPConnect
             }
         }
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['body'] = $body;
         $wp_remote_data['method'] = 'POST';
@@ -144,7 +141,6 @@ class BillplzWooCommerceWPConnect
             $body .= '&' . http_build_query($optional);
         }
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['body'] = $body;
         $wp_remote_data['method'] = 'POST';
@@ -160,7 +156,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v4/collections/' . $id;
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['method'] = 'GET';
 
@@ -175,7 +170,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v4/open_collections/' . $id;
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['method'] = 'GET';
 
@@ -190,7 +184,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v4/open_collections?' . http_build_query($parameter);
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['method'] = 'GET';
 
@@ -207,7 +200,6 @@ class BillplzWooCommerceWPConnect
 
         $data = array('title' => $title);
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['body'] = http_build_query($data);
         $wp_remote_data['method'] = 'POST';
@@ -223,7 +215,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v4/mass_payment_instruction_collections/' . $id;
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['method'] = 'GET';
 
@@ -244,7 +235,6 @@ class BillplzWooCommerceWPConnect
 
         $data = array_merge($parameter, $optional);
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['body'] = http_build_query($data);
         $wp_remote_data['method'] = 'POST';
@@ -260,7 +250,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v4/mass_payment_instructions/' . $id;
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['body'] = http_build_query($data);
         $wp_remote_data['method'] = 'POST';
@@ -376,7 +365,6 @@ class BillplzWooCommerceWPConnect
 
         $data = array('title' => $title);
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['body'] = http_build_query(array());
         $wp_remote_data['method'] = 'POST';
@@ -394,7 +382,6 @@ class BillplzWooCommerceWPConnect
 
         $data = array_merge($parameter, $optional);
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['body'] = http_build_query($data);
         $wp_remote_data['method'] = 'POST';
@@ -410,7 +397,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v3/bills/' . $id;
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['method'] = 'GET';
 
@@ -425,7 +411,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v3/bills/' . $id;
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['body'] = http_build_query(array());
         $wp_remote_data['method'] = 'DELETE';
@@ -441,7 +426,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v3/check/bank_account_number/' . $id;
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['method'] = 'GET';
 
@@ -456,7 +440,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v3/collections/' . $id . '/payment_methods';
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['method'] = 'GET';
 
@@ -471,7 +454,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v3/bills/' . $id . '/transactions?' . http_build_query($parameter);
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['method'] = 'GET';
 
@@ -495,7 +477,6 @@ class BillplzWooCommerceWPConnect
             $body[] = http_build_query($param);
         }
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['body'] = implode('&', $body);
         $wp_remote_data['method'] = 'PUT';
@@ -518,7 +499,6 @@ class BillplzWooCommerceWPConnect
 
         $url = $this->url . 'v3/bank_verification_services?' . $parameter;
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['method'] = 'GET';
 
@@ -533,7 +513,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v3/bank_verification_services/' . $id;
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['method'] = 'GET';
 
@@ -548,7 +527,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v3/bank_verification_services';
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['body'] = http_build_query($parameter);
         $wp_remote_data['method'] = 'POST';
@@ -564,7 +542,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v3/fpx_banks';
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['method'] = 'GET';
 
@@ -579,7 +556,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v4/payment_gateways';
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['method'] = 'GET';
 
@@ -594,7 +570,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v5/payment_order_collections/' . $id;
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['body'] = $parameter;
         $wp_remote_data['method'] = 'GET';
@@ -610,7 +585,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v5/payment_orders/' . $id;
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['body'] = $parameter;
         $wp_remote_data['method'] = 'GET';
@@ -626,7 +600,6 @@ class BillplzWooCommerceWPConnect
     {
         $url = $this->url . 'v5/payment_orders';
 
-        $wp_remote_data['sslverify'] = false;
         $wp_remote_data['headers'] = $this->header;
         $wp_remote_data['body'] = http_build_query($parameter);
         $wp_remote_data['method'] = 'POST';

--- a/includes/wc_billplz_gateway.php
+++ b/includes/wc_billplz_gateway.php
@@ -106,20 +106,9 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
 
     $data = wp_parse_args( $data, $defaults );
 
-    // Get the first part of the string before the '-' character
-    $payment_order_collection_id_array = explode( '-', $this->payment_order_collection_id );
-
-    $hidden_payment_order_collection_array = array();
-
-    foreach ( $payment_order_collection_id_array as $key => $value ) {
-      if ( $key === 0 ) {
-        $hidden_payment_order_collection_array[] = $value;
-      } else {
-        $hidden_payment_order_collection_array[] = str_repeat( '*', strlen( $value ) );
-      }
-    }
-
-    $hidden_payment_order_collection_id = implode( '-', $hidden_payment_order_collection_array );
+    // Display only the first 6 characters of the payment order collection ID and conceal the remainder with "*"
+    $hidden_payment_order_collection_id = substr( $this->payment_order_collection_id, 0, 6 );
+    $hidden_payment_order_collection_id .= str_repeat( '*', strlen( $this->payment_order_collection_id ) - 6 );
 
     ob_start();
     ?>

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wanzulnet
 Tags: billplz
 Tested up to: 6.3
-Stable tag: 3.28.0
+Stable tag: 3.28.1
 Requires at least: 4.6
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -22,6 +22,9 @@ Install this plugin to accept payment using Billplz.
 * Enable X Signature Key at Billplz Account Settings
 
 == Changelog ==
+
+= 3.28.1 - 2023-10-25 =
+* FIXED: Resolved SSL verification error during the WP remote request by removing the 'sslverify' parameter
 
 = 3.28.0 - 2023-08-23 =
 * NEW: Support order refunds via Billplz payment order


### PR DESCRIPTION
### Changes proposed in this Pull Request:
- Resolved SSL verification error during the WP remote request by removing the 'sslverify' parameter
- Code restructure for the function to hide the payment order collection ID in the WordPress admin