### PR TITLE
Remove Deprecation Notice of WooCommerce Log File Path Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Accept payment using Billplz.
 Compatible up to:
 - PHP 8.1
-- Wordpress 6.4.1
+- Wordpress 6.5
 - Woocommerce 8.3.1
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Accept payment using Billplz.
 Compatible up to:
 - PHP 8.1
 - Wordpress 6.5
-- Woocommerce 8.3.1
+- Woocommerce 8.6.1
 
 # Installation
 

--- a/billplzWoo.php
+++ b/billplzWoo.php
@@ -9,6 +9,7 @@
  * Version: 3.28.3
  * Requires PHP: 7.0
  * Requires at least: 4.6
+ * Requires Plugins: woocommerce
  * License: GPLv3
  * Text Domain: bfw
  * Domain Path: /languages/

--- a/billplzWoo.php
+++ b/billplzWoo.php
@@ -6,7 +6,7 @@
  * Description: Billplz. Fair payment platform.
  * Author: Billplz Sdn Bhd
  * Author URI: http://github.com/billplz/billplz-for-woocommerce
- * Version: 3.28.3
+ * Version: 3.28.4
  * Requires PHP: 7.0
  * Requires at least: 4.6
  * Requires Plugins: woocommerce

--- a/billplzWoo.php
+++ b/billplzWoo.php
@@ -14,7 +14,7 @@
  * Text Domain: bfw
  * Domain Path: /languages/
  * WC requires at least: 3.0
- * WC tested up to: 8.3.1
+ * WC tested up to: 8.6.1
  */
 
 defined('ABSPATH') || exit;

--- a/includes/admin/bfw_settings.php
+++ b/includes/admin/bfw_settings.php
@@ -188,7 +188,7 @@ function bfw_get_settings() {
     'type' => 'checkbox',
     'label' => __('Enable logging', 'bfw'),
     'default' => 'no',
-    'description' => sprintf(__('Log Billplz events, such as IPN requests, inside <code>%s</code>', 'bfw'), wc_get_log_file_path('billplz')),
+    'description' => sprintf(__('Log Billplz events, such as IPN requests, inside <code>%s</code>', 'bfw'), WC_Log_Handler_File::get_log_file_path('billplz')),
   );
 
   $settings['bill_option'] = array(

--- a/includes/wc_billplz_gateway.php
+++ b/includes/wc_billplz_gateway.php
@@ -643,6 +643,10 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
 
     $order = wc_get_order($order_id);
 
+    if (!$order) {
+        wp_die(__('Order not found.'));
+    }
+
     if (!$data['paid'] && $data['type'] === 'bill_redirect'){
       if (isset($data['transaction_status']) && $data['transaction_status'] == 'pending'){
         wp_redirect($order->get_view_order_url());

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Billplz for WooCommerce ===
 Contributors: wanzulnet, yiedpozi
 Tags: billplz
-Tested up to: 6.4.1
+Tested up to: 6.5
 Stable tag: 3.28.3
 Requires at least: 4.6
 License: GPL-3.0-or-later

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wanzulnet, yiedpozi
 Tags: billplz
 Tested up to: 6.5
-Stable tag: 3.28.3
+Stable tag: 3.28.4
 Requires at least: 4.6
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -22,6 +22,9 @@ Install this plugin to accept payment using Billplz.
 * Enable X Signature Key at Billplz Account Settings
 
 == Changelog ==
+
+= 3.28.4 - 2024-03-18 =
+* FIXED: Remove deprecation notice of woocommerce log file path
 
 = 3.28.3 - 2023-11-28 =
 * NEW: Added support for WooCommerce checkout blocks


### PR DESCRIPTION
### Changes proposed in this Pull Request:
- Remove deprecation notice of woocommerce log file path function
- Bump WordPress & WooCommerce "Tested up to" version to 6.5 and 8.6.1 respectively

Closes https://github.com/Billplz/Billplz-for-WooCommerce/issues/27.