### PR TITLE
Compatibility Fixes for WooCommerce Refund via Payment Order

### DIFF
--- a/assets/css/admin-order.css
+++ b/assets/css/admin-order.css
@@ -47,33 +47,12 @@
 }
 
 /* Order Refund Information  */
-#bfw-order-refund-information {
-    background-color: #fff;
-    border-radius: 50px;
-    margin-top: 7px;
-    display: flex;
+.bfw-order-refund-info {
+    margin-top: 5px;
 }
-#bfw-order-refund-information .bfw-order-refund-label,
-#bfw-order-refund-information .bfw-order-refund-id {
-    font-weight: 500;
-    border: 2px solid #3784f4;
-    border-radius: 50px;
-    padding: 4px 15px;
-    white-space: nowrap;
-}
-#bfw-order-refund-information .bfw-order-refund-label {
-    background-color: #3784f4;
-    color: #fff;
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-    padding-right: 7px;
-}
-#bfw-order-refund-information .bfw-order-refund-id {
+.bfw-order-refund-info span.bfw-brand-text {
+    font-weight: bold;
     color: #3784f4;
-    border-left: 0;
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-    padding-left: 7px;
 }
 
 /* Required asterisk */

--- a/assets/js/admin-order.js
+++ b/assets/js/admin-order.js
@@ -99,7 +99,7 @@ jQuery(document).ready(function($) {
 
                 var data = {
                     action                : 'bfw_create_refund',
-                    order_id              : bfw_admin_order_metaboxes.order_id,
+                    order_id              : woocommerce_admin_meta_boxes.post_id,
                     refund_amount         : refund_amount,
                     refunded_amount       : refunded_amount,
                     refund_reason         : refund_reason,

--- a/billplzWoo.php
+++ b/billplzWoo.php
@@ -6,7 +6,7 @@
  * Description: Billplz. Fair payment platform.
  * Author: Billplz Sdn Bhd
  * Author URI: http://github.com/billplz/billplz-for-woocommerce
- * Version: 3.28.4
+ * Version: 3.28.5
  * Requires PHP: 7.0
  * Requires at least: 4.6
  * Requires Plugins: woocommerce
@@ -14,7 +14,7 @@
  * Text Domain: bfw
  * Domain Path: /languages/
  * WC requires at least: 3.0
- * WC tested up to: 8.6.1
+ * WC tested up to: 8.9.1
  */
 
 defined('ABSPATH') || exit;

--- a/includes/views/html-order-refund-information.php
+++ b/includes/views/html-order-refund-information.php
@@ -8,7 +8,13 @@ if ( !$billplz_payment_order ) {
 }
 ?>
 
-<a href="<?php echo esc_url( $billplz_payment_order['url'] ); ?>" target="_blank" id="bfw-order-refund-information">
-    <span class="bfw-order-refund-label"><?php esc_html_e( 'Billplz Refund ID :', 'bfw' ); ?></span>
-    <span class="bfw-order-refund-id"><?php echo esc_html( $billplz_payment_order['id'] ); ?></span>
-</a>
+<div class="bfw-order-refund-info">
+    <?php
+    printf(
+        __( 'Processed via <span class="bfw-brand-text">Billplz</span> Payment Order<br><strong>Payment Order ID:</strong> <span class="help_tip" aria-label="Status: %3$s" data-tip="Status: %3$s"><a href="%2$s" target="_blank">%1$s</a></span>', 'bfw' ),
+        $billplz_payment_order['id'],
+        $billplz_payment_order['url'],
+        strtoupper( $billplz_payment_order['status'] )
+    );
+    ?>
+</div>

--- a/includes/wc_billplz_gateway.php
+++ b/includes/wc_billplz_gateway.php
@@ -13,6 +13,12 @@ add_filter('woocommerce_payment_gateways', 'bfw_add_gateway');
 // Action hooks that needs to register outside of the payment gateway class
 add_action( 'wp_ajax_bfw_create_refund', array( 'WC_Billplz_Gateway', 'create_refund' ) );
 
+// "admin_notices" hook must be registered outside gateway class to avoid duplicate notices in admin screen
+add_action('admin_notices', function() {
+  $wc_billplz_gateway = new WC_Billplz_Gateway();
+  $wc_billplz_gateway->display_errors();
+});
+
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 

--- a/includes/wc_billplz_gateway.php
+++ b/includes/wc_billplz_gateway.php
@@ -11,12 +11,17 @@ function bfw_add_gateway($methods)
 add_filter('woocommerce_payment_gateways', 'bfw_add_gateway');
 
 // Action hooks that needs to register outside of the payment gateway class
-add_action( 'wp_ajax_bfw_create_refund', array( 'WC_Billplz_Gateway', 'create_refund' ) );
+add_action('wp_ajax_bfw_create_refund', array('WC_Billplz_Gateway', 'create_refund'));
 
 // "admin_notices" hook must be registered outside gateway class to avoid duplicate notices in admin screen
 add_action('admin_notices', function() {
   $wc_billplz_gateway = new WC_Billplz_Gateway();
   $wc_billplz_gateway->display_errors();
+});
+
+// Display the saved payment order data for specified refund
+add_action('woocommerce_after_order_refund_item_name', function($refund) {
+  include BFW_PLUGIN_DIR . '/includes/views/html-order-refund-information.php';
 });
 
 use Automattic\WooCommerce\Utilities\OrderUtil;
@@ -238,8 +243,6 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
   {
     add_action('admin_enqueue_scripts', array(&$this, 'enqueue_scripts'));
 
-    add_action('admin_notices', array(&$this, 'display_errors'));
-
     add_action('before_woocommerce_pay_form', array(&$this, 'before_woocommerce_pay_form'), 10, 3);
 
     add_action('woocommerce_thankyou_billplz', array(&$this, 'thankyou_page'));
@@ -247,24 +250,19 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
     add_action('woocommerce_update_options_payment_gateways_billplz', array(&$this, 'process_admin_options'));
     add_action('woocommerce_api_wc_billplz_gateway', array(&$this, 'check_response'));
 
-    add_action('add_meta_boxes', array(&$this, 'register_metaboxes'));
-    add_action('woocommerce_after_order_refund_item_name', array(&$this, 'show_refund_info'));
+    add_action('add_meta_boxes', array(&$this, 'register_metaboxes'), 10, 2);
   }
 
-  public function enqueue_scripts($hook_suffix)
+  public function enqueue_scripts()
   {
-    global $post_type;
+    wp_enqueue_style('bfw-admin-order', BFW_PLUGIN_URL . 'assets/css/admin-order.css', array('woocommerce_admin_styles'), BFW_PLUGIN_VER, 'all');
+    wp_enqueue_script('bfw-admin-order', BFW_PLUGIN_URL . 'assets/js/admin-order.js', array('jquery', 'wc-admin-order-meta-boxes'), BFW_PLUGIN_VER, true);
 
-    if ($post_type === 'shop_order') {
-      wp_enqueue_style('bfw-admin-order', BFW_PLUGIN_URL . 'assets/css/admin-order.css', array('woocommerce_admin_styles'), BFW_PLUGIN_VER, 'all');
-      wp_enqueue_script('bfw-admin-order', BFW_PLUGIN_URL . 'assets/js/admin-order.js', array('jquery', 'wc-admin-order-meta-boxes'), BFW_PLUGIN_VER, true);
-
-      wp_localize_script('bfw-admin-order', 'bfw_admin_order_metaboxes', array(
-        'ajax_url'               => admin_url('admin-ajax.php'),
-        'create_refund_nonce'    => wp_create_nonce('bfw-create-refund'),
-        'refund_success_message' => __( 'Refund created. The refund payment will be processed via Billplz.', 'bfw' ),
-      ));
-    }
+    wp_localize_script('bfw-admin-order', 'bfw_admin_order_metaboxes', array(
+      'ajax_url'               => admin_url('admin-ajax.php'),
+      'create_refund_nonce'    => wp_create_nonce('bfw-create-refund'),
+      'refund_success_message' => __( 'Refund created. The refund payment will be processed via Billplz.', 'bfw' ),
+    ));
   }
 
   // Display admin error messages
@@ -863,11 +861,9 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
         && $order->get_remaining_refund_amount() > 0;
   }
 
-  public function register_metaboxes()
+  public function register_metaboxes( $post_type, $post )
   {
-    global $post;
-
-    if (OrderUtil::get_order_type($post) === 'shop_order') {
+    if ( OrderUtil::get_order_type($post) === 'shop_order' ) {
       $order = wc_get_order($post);
 
       if ( $order && $order->is_paid() && $order->get_payment_method() === $this->id ) {
@@ -880,10 +876,8 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
     }
   }
 
-  public function refund_metabox()
+  public function refund_metabox($post)
   {
-    global $post;
-
     if ( OrderUtil::get_order_type( $post ) === 'shop_order' ) {
       $order = wc_get_order($post);
 
@@ -1261,11 +1255,5 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
     $refund_note .= $reference;
 
     $order->add_order_note( $refund_note );
-  }
-
-  // Display the saved payment order data for specified order
-  public function show_refund_info( $refund )
-  {
-    include BFW_PLUGIN_DIR . '/includes/views/html-order-refund-information.php';
   }
 }

--- a/includes/wc_billplz_gateway.php
+++ b/includes/wc_billplz_gateway.php
@@ -261,7 +261,6 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
 
       wp_localize_script('bfw-admin-order', 'bfw_admin_order_metaboxes', array(
         'ajax_url'               => admin_url('admin-ajax.php'),
-        'order_id'               => get_the_ID(),
         'create_refund_nonce'    => wp_create_nonce('bfw-create-refund'),
         'refund_success_message' => __( 'Refund created. The refund payment will be processed via Billplz.', 'bfw' ),
       ));

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Billplz for WooCommerce ===
 Contributors: wanzulnet, yiedpozi
 Tags: billplz
-Tested up to: 6.5
-Stable tag: 3.28.4
+Tested up to: 6.5.3
+Stable tag: 3.28.5
 Requires at least: 4.6
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,10 @@ Install this plugin to accept payment using Billplz.
 
 == Changelog ==
 
+= 3.28.5 - 2024-05-29 =
+* FIXED: Duplicate admin notice issue
+* FIXED: Missing "Billplz Refund" metabox in order details page when HPOS is enabled
+
 = 3.28.4 - 2024-03-18 =
 * FIXED: Remove deprecation notice of woocommerce log file path
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:
- Resolve duplicate admin notices issue
- Resolve missing "Billplz Refund" metabox in order details page (admin) when HPOS is enabled
- Update UI for Billplz payment order information in order refund details
- Bump WordPress & WooCommerce "Tested up to" version to 6.5.3 and 8.9.1 respectively

![image](https://github.com/Billplz/Billplz-for-WooCommerce/assets/7779434/398b3a24-3a14-48e2-8b48-078ca5118541)
_Before: Payment Order Information for Order Refund_

![image](https://github.com/Billplz/Billplz-for-WooCommerce/assets/7779434/4e03314f-c79c-403f-80da-0c3ec69f0254)
_After: Payment Order Information for Order Refund_