### PR TITLE
Remove Special Characters in Payment Order Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Accept payment using Billplz.
 Compatible up to:
 - PHP 8.1
-- Wordpress 6.5.4
-- Woocommerce 8.9.3
+- Wordpress 6.6.1
+- Woocommerce 9.1.4
 
 # Installation
 

--- a/billplzWoo.php
+++ b/billplzWoo.php
@@ -6,7 +6,7 @@
  * Description: Billplz. Fair payment platform.
  * Author: Billplz Sdn Bhd
  * Author URI: http://github.com/billplz/billplz-for-woocommerce
- * Version: 3.28.6
+ * Version: 3.28.7
  * Requires PHP: 7.0
  * Requires at least: 4.6
  * Requires Plugins: woocommerce
@@ -14,7 +14,7 @@
  * Text Domain: bfw
  * Domain Path: /languages/
  * WC requires at least: 3.0
- * WC tested up to: 8.9.3
+ * WC tested up to: 9.1.4
  */
 
 defined('ABSPATH') || exit;

--- a/includes/views/html-order-refund-metabox.php
+++ b/includes/views/html-order-refund-metabox.php
@@ -13,15 +13,15 @@
     </div>
     <div class="bfw-metabox-field-container bank-account-number-field-container">
         <label for="bank-account-number" class="bfw-metabox-label"><?php _e( 'Account Number', 'bfw' ); ?><span class="bfw-required">*</span></label>
-        <input id="refund-bank-account-number" type="number" class="bfw-metabox-field" value="<?php echo esc_attr( $order->get_meta('bfw_order_refund_bank_account_number') ); ?>"/>
+        <input id="refund-bank-account-number" type="number" class="bfw-metabox-field" />
     </div>
     <div class="bfw-metabox-field-container name-field-container">
         <label for="bank-account-name" class="bfw-metabox-label"><?php _e( 'Account Name', 'bfw' ); ?><span class="bfw-required">*</span></label>
-        <input id="refund-bank-account-name" type="text" class="bfw-metabox-field" value="<?php echo esc_attr( $order->get_meta('bfw_order_refund_bank_account_name') ); ?>"/>
+        <input id="refund-bank-account-name" type="text" class="bfw-metabox-field" />
     </div>
     <div class="bfw-metabox-field-container identity-number-field-container">
         <label for="identity-number" class="bfw-metabox-label"><?php _e( 'IC Number', 'bfw' ); ?><span class="bfw-required">*</span></label>
-        <input id="refund-identity-number" type="number" class="bfw-metabox-field" value="<?php echo esc_attr( $order->get_meta('bfw_order_refund_identity_number') ); ?>"/>
+        <input id="refund-identity-number" type="number" class="bfw-metabox-field" />
     </div>
     <div class="bfw-metabox-field-container amount-field-container">
         <label for="amount" class="bfw-metabox-label"><?php _e( 'Amount', 'bfw'); ?><span class="bfw-required">*</span></label>
@@ -29,7 +29,7 @@
     </div>
     <div class="bfw-metabox-field-container description-field-container">
         <label for="description" class="bfw-metabox-label"><?php _e( 'Description', 'bfw' ); ?><span class="bfw-required">*</span></label>
-        <input id="refund-description" type="text" class="bfw-metabox-field" value="<?php echo esc_attr( $order->get_meta('bfw_order_refund_description') ?: sprintf( __( 'Refund for Order #%d', 'bfw' ), $order->get_id() ) ); ?>"/>
+        <input id="refund-description" type="text" class="bfw-metabox-field" value="<?php echo esc_attr( sprintf( __( 'Refund for Order %d', 'bfw' ), $order->get_id() ) ); ?>"/>
     </div>
     <div class="bfw-metabox-submit-container">
         <?php

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Billplz for WooCommerce ===
 Contributors: wanzulnet, yiedpozi
 Tags: billplz
-Tested up to: 6.5.4
-Stable tag: 3.28.6
+Tested up to: 6.6.1
+Stable tag: 3.28.7
 Requires at least: 4.6
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -22,6 +22,9 @@ Install this plugin to accept payment using Billplz.
 * Enable X Signature Key at Billplz Account Settings
 
 == Changelog ==
+
+= 3.28.7 - 2024-07-29 =
+* FIXED: Remove special characters from the Payment Order description
 
 = 3.28.6 - 2024-06-13 =
 * FIXED: Missing script dependencies for refund metabox


### PR DESCRIPTION
### Changes proposed in this Pull Request:
- Remove `#` character in the payment order description for order refund.