### PR TITLE
Missing FPX Banks on Payment Options Dropdown

### DIFF
--- a/billplzWoo.php
+++ b/billplzWoo.php
@@ -6,7 +6,7 @@
  * Description: Billplz. Fair payment platform.
  * Author: Billplz Sdn Bhd
  * Author URI: http://github.com/billplz/billplz-for-woocommerce
- * Version: 3.28.9
+ * Version: 3.28.10
  * Requires PHP: 7.0
  * Requires at least: 4.6
  * Requires Plugins: woocommerce
@@ -52,7 +52,7 @@ class Woocommerce_Billplz {
     $this->define( 'BFW_PLUGIN_URL', plugin_dir_url(BFW_PLUGIN_FILE));
     $this->define( 'BFW_PLUGIN_DIR',  dirname(BFW_PLUGIN_FILE) );
     $this->define( 'BFW_BASENAME',  plugin_basename(BFW_PLUGIN_FILE) );
-    $this->define( 'BFW_PLUGIN_VER',  '3.28.9' );
+    $this->define( 'BFW_PLUGIN_VER',  '3.28.10' );
   }
 
   public function check_environment() {

--- a/includes/helpers/billplz_payment_option.php
+++ b/includes/helpers/billplz_payment_option.php
@@ -15,6 +15,7 @@ class BillplzPaymentOption
             'BIMB0340' => __( 'Bank Islam Internet Banking', 'bfw' ),
             'BKRM0602' => __( 'i-Rakyat', 'bfw' ),
             'BMMB0341' => __( 'i-Muamalat', 'bfw' ),
+            'BOCM01' => __( 'Bank of China', 'bfw' ),
             'BSN0601' => __( 'myBSN', 'bfw' ),
             'CIT0219' => __( 'Citibank Online', 'bfw' ),
             'HLB0224' => __( 'HLB Connect', 'bfw' ),
@@ -86,7 +87,6 @@ class BillplzPaymentOption
         if ( $sandbox ) {
             $sandbox_banks = [
                 'ABB0234' => __( 'Affin Bank', 'bfw' ),
-                'BOCM01' => __( 'Bank of China', 'bfw' ),
                 'UOB0229' => __( 'UOB Bank', 'bfw' ),
                 'TEST0001' => __( 'FPX TEST 1', 'bfw' ),
                 'TEST0002' => __( 'FPX TEST 2', 'bfw' ),

--- a/includes/helpers/billplz_payment_option.php
+++ b/includes/helpers/billplz_payment_option.php
@@ -82,10 +82,8 @@ class BillplzPaymentOption
             'B2B1-UOB0228' => __( 'UOB BIBPlus (Business)', 'bfw' ),
         );
 
-        $sandbox_banks = array();
-
         if ( $sandbox ) {
-            $sandbox_banks = [
+            $banks = [
                 'ABB0234' => __( 'Affin Bank', 'bfw' ),
                 'UOB0229' => __( 'UOB Bank', 'bfw' ),
                 'TEST0001' => __( 'FPX TEST 1', 'bfw' ),
@@ -102,7 +100,7 @@ class BillplzPaymentOption
             ];
         }
 
-        return array_merge( $banks, $sandbox_banks );
+        return $banks;
     }
 
     public static function getSwiftBanks( bool $sandbox = false )
@@ -131,12 +129,11 @@ class BillplzPaymentOption
         ];
 
         if ( $sandbox ) {
-            $sandbox_swift_banks = [
+            $swift_banks = [
                 'DUMMYBANKVERIFIED' => __( 'Billplz Dummy Bank Verified', 'bfw' ),
             ];
         }
 
-        // Sandbox first
-        return array_merge( $sandbox_swift_banks, $swift_banks );
+        return $swift_banks;
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ Install this plugin to accept payment using Billplz.
 
 == Changelog ==
 
-= 3.28.9 - 2025-01-28 =
+= 3.28.10 - 2025-01-28 =
 * FIXED: Missing payment option - Bank of China
 * FIXED: Exclude live FPX and SWIFT banks when sandbox is enabled
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wanzulnet, yiedpozi
 Tags: billplz
 Tested up to: 6.7.1
-Stable tag: 3.28.9
+Stable tag: 3.28.10
 Requires at least: 4.6
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -22,6 +22,10 @@ Install this plugin to accept payment using Billplz.
 * Enable X Signature Key at Billplz Account Settings
 
 == Changelog ==
+
+= 3.28.9 - 2025-01-28 =
+* FIXED: Missing payment option - Bank of China
+* FIXED: Exclude live FPX and SWIFT banks when sandbox is enabled
 
 = 3.28.9 - 2025-01-27 =
 * NEW: Add payment icon in WooCommerce checkout block


### PR DESCRIPTION
### Changes proposed in this Pull Request:
- Fix missing payment option - Bank of China.
- Exclude live FPX and SWIFT banks when sandbox is enabled.