### PR TITLE
Fix: Remove IC Number Field from Refund Form

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Accept payment using Billplz.
 Compatible up to:
 - PHP 8.1
-- WordPress 6.7.1
-- WooCommerce 9.6.0
+- WordPress 6.8
+- WooCommerce 9.8.2
 
 # Installation
 

--- a/assets/js/admin-order.js
+++ b/assets/js/admin-order.js
@@ -94,7 +94,6 @@ jQuery(document).ready(function($) {
                 var bank                = order_refund_form.find('#refund-bank').val();
                 var bank_account_number = order_refund_form.find('#refund-bank-account-number').val();
                 var bank_account_name   = order_refund_form.find('#refund-bank-account-name').val();
-                var identity_number     = order_refund_form.find('#refund-identity-number').val();
                 var description         = order_refund_form.find('#refund-description').val();
 
                 var data = {
@@ -111,7 +110,6 @@ jQuery(document).ready(function($) {
                     bank                  : bank,
                     bank_account_number   : bank_account_number,
                     bank_account_name     : bank_account_name,
-                    identity_number       : identity_number,
                     description           : description,
 
                     security              : bfw_admin_order_metaboxes.create_refund_nonce

--- a/billplzWoo.php
+++ b/billplzWoo.php
@@ -6,7 +6,7 @@
  * Description: Billplz. Fair payment platform.
  * Author: Billplz Sdn Bhd
  * Author URI: http://github.com/billplz/billplz-for-woocommerce
- * Version: 3.28.10
+ * Version: 3.28.11
  * Requires PHP: 7.0
  * Requires at least: 4.6
  * Requires Plugins: woocommerce
@@ -14,7 +14,7 @@
  * Text Domain: bfw
  * Domain Path: /languages/
  * WC requires at least: 3.0
- * WC tested up to: 9.1.4
+ * WC tested up to: 9.8.2
  */
 
 defined('ABSPATH') || exit;
@@ -52,7 +52,7 @@ class Woocommerce_Billplz {
     $this->define( 'BFW_PLUGIN_URL', plugin_dir_url(BFW_PLUGIN_FILE));
     $this->define( 'BFW_PLUGIN_DIR',  dirname(BFW_PLUGIN_FILE) );
     $this->define( 'BFW_BASENAME',  plugin_basename(BFW_PLUGIN_FILE) );
-    $this->define( 'BFW_PLUGIN_VER',  '3.28.10' );
+    $this->define( 'BFW_PLUGIN_VER',  '3.28.11' );
   }
 
   public function check_environment() {

--- a/includes/views/html-order-refund-metabox.php
+++ b/includes/views/html-order-refund-metabox.php
@@ -19,10 +19,6 @@
         <label for="bank-account-name" class="bfw-metabox-label"><?php _e( 'Account Name', 'bfw' ); ?><span class="bfw-required">*</span></label>
         <input id="refund-bank-account-name" type="text" class="bfw-metabox-field" />
     </div>
-    <div class="bfw-metabox-field-container identity-number-field-container">
-        <label for="identity-number" class="bfw-metabox-label"><?php _e( 'IC Number', 'bfw' ); ?><span class="bfw-required">*</span></label>
-        <input id="refund-identity-number" type="number" class="bfw-metabox-field" />
-    </div>
     <div class="bfw-metabox-field-container amount-field-container">
         <label for="amount" class="bfw-metabox-label"><?php _e( 'Amount', 'bfw'); ?><span class="bfw-required">*</span></label>
         <input id="refund-amount" type="number" class="bfw-metabox-field" step="0.01"/>

--- a/includes/wc_billplz_gateway.php
+++ b/includes/wc_billplz_gateway.php
@@ -943,7 +943,6 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
     $bank                   = isset( $_POST['bank'] ) ? sanitize_text_field( wp_unslash( $_POST['bank'] ) ) : '';
     $bank_account_number    = isset( $_POST['bank_account_number'] ) ? sanitize_text_field( wp_unslash( $_POST['bank_account_number'] ) ) : '';
     $bank_account_name      = isset( $_POST['bank_account_name'] ) ? sanitize_text_field( wp_unslash( $_POST['bank_account_name'] ) ) : '';
-    $identity_number        = isset( $_POST['identity_number'] ) ? sanitize_text_field( wp_unslash( $_POST['identity_number'] ) ) : '';
     $refund_description     = isset( $_POST['description'] ) ? sanitize_text_field( wp_unslash( $_POST['description'] ) ) : '';
 
     try {
@@ -975,10 +974,6 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
         throw new Exception( __( 'Please enter the bank account name.', 'bfw' ) );
       }
 
-      if ( !$identity_number ) {
-        throw new Exception( __( 'Please enter the identification number (IC/SSM number) for bank account verification purposes.', 'bfw' ) );
-      }
-
       if ( !$refund_description ) {
         throw new Exception( __( 'Please enter the refund description.', 'bfw' ) );
       }
@@ -988,7 +983,6 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
         'bank'                => $bank,
         'bank_account_number' => $bank_account_number,
         'bank_account_name'   => $bank_account_name,
-        'identity_number'     => $identity_number,
         'description'         => $refund_description,
       );
 
@@ -1094,7 +1088,6 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
         'bank'                => '',
         'bank_account_number' => '',
         'bank_account_name'   => '',
-        'identity_number'     => '',
         'description'         => '',
       ) );
 
@@ -1114,10 +1107,6 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
         throw new Exception( __( 'Please enter the bank account name.', 'bfw' ) );
       }
 
-      if ( !$refund_data['identity_number'] ) {
-        throw new Exception( __( 'Please enter the identification number (IC/SSM number) for bank account verification purposes.', 'bfw' ) );
-      }
-
       if ( !$refund_data['description'] ) {
         throw new Exception( __( 'Please enter the refund description.', 'bfw' ) );
       }
@@ -1132,7 +1121,6 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
         'payment_order_collection_id' => $this->payment_order_collection_id,
         'bank_code'                   => $refund_data['bank'],
         'bank_account_number'         => $refund_data['bank_account_number'],
-        'identity_number'             => $refund_data['identity_number'],
         'name'                        => $refund_data['bank_account_name'],
         'description'                 => $refund_data['description'],
         'total'                       => absint( $refund_data['amount'] * 100 ),

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wanzulnet, yiedpozi
 Tags: billplz
 Tested up to: 6.8
-Stable tag: 3.28.10
+Stable tag: 3.28.11
 Requires at least: 4.6
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -22,6 +22,9 @@ Install this plugin to accept payment using Billplz.
 * Enable X Signature Key at Billplz Account Settings
 
 == Changelog ==
+
+= 3.28.11 - 2025-04-28 =
+* FIXED: Removed "IC Number" field from refund form
 
 = 3.28.10 - 2025-01-28 =
 * FIXED: Missing payment option - Bank of China

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Billplz for WooCommerce ===
 Contributors: wanzulnet, yiedpozi
 Tags: billplz
-Tested up to: 6.7.1
+Tested up to: 6.8
 Stable tag: 3.28.10
 Requires at least: 4.6
 License: GPL-3.0-or-later


### PR DESCRIPTION
### Changes proposed in this Pull Request:
- Remove `identity_number` field from refund form
- Bump `Tested Up To` version to WordPress 6.8 and WooCommerce 9.8.2