### PR TITLE
Feature: Automatically Delete Bill When Order Marked as Cancelled

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto
+
+/.gitignore export-ignore
+/.gitattributes export-ignore
+/LICENSE export-ignore
+/README.md export-ignore
+/resources export-ignore
+/LICENSE export-ignore
+/package.json export-ignore
+/webpack.config.js export-ignore

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Accept payment using Billplz.
 Compatible up to:
 - PHP 8.1
-- WordPress 6.8
-- WooCommerce 9.8.2
+- WordPress 6.8.1
+- WooCommerce 9.8.5
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Accept payment using Billplz.
 Compatible up to:
 - PHP 8.1
 - WordPress 6.8.1
-- WooCommerce 9.8.5
+- WooCommerce 9.9.4
 
 # Installation
 

--- a/billplzWoo.php
+++ b/billplzWoo.php
@@ -14,7 +14,7 @@
  * Text Domain: bfw
  * Domain Path: /languages/
  * WC requires at least: 3.0
- * WC tested up to: 9.8.5
+ * WC tested up to: 9.9.4
  */
 
 defined('ABSPATH') || exit;

--- a/billplzWoo.php
+++ b/billplzWoo.php
@@ -6,7 +6,7 @@
  * Description: Billplz. Fair payment platform.
  * Author: Billplz Sdn Bhd
  * Author URI: http://github.com/billplz/billplz-for-woocommerce
- * Version: 3.28.11
+ * Version: 3.28.12
  * Requires PHP: 7.0
  * Requires at least: 4.6
  * Requires Plugins: woocommerce
@@ -14,7 +14,7 @@
  * Text Domain: bfw
  * Domain Path: /languages/
  * WC requires at least: 3.0
- * WC tested up to: 9.8.2
+ * WC tested up to: 9.8.5
  */
 
 defined('ABSPATH') || exit;
@@ -52,7 +52,7 @@ class Woocommerce_Billplz {
     $this->define( 'BFW_PLUGIN_URL', plugin_dir_url(BFW_PLUGIN_FILE));
     $this->define( 'BFW_PLUGIN_DIR',  dirname(BFW_PLUGIN_FILE) );
     $this->define( 'BFW_BASENAME',  plugin_basename(BFW_PLUGIN_FILE) );
-    $this->define( 'BFW_PLUGIN_VER',  '3.28.11' );
+    $this->define( 'BFW_PLUGIN_VER',  '3.28.12' );
   }
 
   public function check_environment() {

--- a/includes/admin/bfw_settings.php
+++ b/includes/admin/bfw_settings.php
@@ -213,6 +213,13 @@ function bfw_get_settings() {
     'desc_tip' => true,
   );
 
+  $settings['auto_delete_bill_order_cancelled'] = array(
+    'title' => __('Auto Delete Bill', 'bfw'),
+    'type' => 'checkbox',
+    'label' => __('Automatically delete a bill upon order marked as "Cancelled"', 'bfw'),
+    'default' => 'no',
+  );
+
   return $settings;
 }
 

--- a/includes/wc_billplz_gateway.php
+++ b/includes/wc_billplz_gateway.php
@@ -593,7 +593,7 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
       'reference_2' => $order_data['id'],
     );
 
-    self::log('Creating bill for order number #' . $order_data['id']);
+    self::log('Creating a bill for order number #' . $order_data['id']);
 
     $billplz = $this->billplz;
     list($rheader, $rbody) = $billplz->toArray($billplz->createBill($parameter, $optional));
@@ -1284,6 +1284,7 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
       return;
     }
 
+    $order_id = $order->get_id();
     $bill_id = $order->get_transaction_id();
 
     if (!$bill_id) {
@@ -1293,7 +1294,9 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
     try {
       $billplz = $this->billplz;
 
-      if (!empty(bfw_get_bill_state_legacy($order->get_id(), $bill_id))){
+      if (!empty(bfw_get_bill_state_legacy($order_id, $bill_id))){
+        self::log("Deleting bill ({$bill_id}) for order number #{$order_id}");
+
         bfw_delete_bill($bill_id);
         list($rheader, $rbody) = $billplz->toArray($billplz->deleteBill($bill_id));
 
@@ -1304,6 +1307,8 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
               $bill_id,
             ),
           );
+
+          self::log("Bill ({$bill_id}) deleted for order number #{$order_id}");
 
           return;
         }
@@ -1324,6 +1329,8 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
           $e->getMessage(),
         ),
       );
+
+      self::log('Failed to delete bill (' . $bill_id . '): ' . $e->getMessage());
     }
   }
 }

--- a/includes/wc_billplz_gateway.php
+++ b/includes/wc_billplz_gateway.php
@@ -1286,6 +1286,10 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
 
     $bill_id = $order->get_transaction_id();
 
+    if (!$bill_id) {
+      return;
+    }
+
     try {
       $billplz = $this->billplz;
 
@@ -1300,6 +1304,8 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
               $bill_id,
             ),
           );
+
+          return;
         }
 
         $error_message = isset($rbody['error']['message']) ? $rbody['error']['message'] : null;

--- a/includes/wc_billplz_gateway.php
+++ b/includes/wc_billplz_gateway.php
@@ -266,7 +266,7 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
 
     add_action('add_meta_boxes', array(&$this, 'register_metaboxes'), 10, 2);
 
-    add_action('woocommerce_after_order_object_save', array(&$this, 'delete_bill_cancelled_order'));
+    add_action('woocommerce_order_status_changed', array(&$this, 'delete_bill_on_order_cancelled'), 10, 4);
   }
 
   public function enqueue_scripts()
@@ -1274,7 +1274,7 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
     $order->add_order_note( $refund_note );
   }
 
-  public function delete_bill_cancelled_order($order)
+  public function delete_bill_on_order_cancelled($order_id, $status_from, $status_to, $order)
   {
     if ($order->get_status() !== 'cancelled') {
       return;

--- a/includes/wc_billplz_gateway.php
+++ b/includes/wc_billplz_gateway.php
@@ -49,6 +49,7 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
   private $instructions;
 
   private $is_advanced_checkout;
+  private $auto_delete_bill_order_cancelled;
 
   private $connect;
   private $billplz;
@@ -89,6 +90,7 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
     $this->instructions = $this->get_option('instructions');
 
     $this->is_advanced_checkout = 'yes' === $this->get_option('is_advanced_checkout');
+    $this->auto_delete_bill_order_cancelled = 'yes' === $this->get_option('auto_delete_bill_order_cancelled');
 
     if ( !$this->is_valid_for_use() ) {
       $this->enabled = 'no';
@@ -1275,6 +1277,10 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
   public function delete_bill_cancelled_order($order)
   {
     if ($order->get_status() !== 'cancelled') {
+      return;
+    }
+
+    if (!$this->auto_delete_bill_order_cancelled) {
       return;
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ Install this plugin to accept payment using Billplz.
 
 == Changelog ==
 
-= 3.28.12 - 2025-06-03 =
+= 3.28.12 - 2025-06-18 =
 * ADDED: Enable/disable automatic bill deletion upon order marked as "Cancelled"
 
 = 3.28.11 - 2025-04-28 =

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ Install this plugin to accept payment using Billplz.
 
 == Changelog ==
 
-= 3.28.12 - 2025-05-xx =
+= 3.28.12 - 2025-06-03 =
 * ADDED: Enable/disable automatic bill deletion upon order marked as "Cancelled"
 
 = 3.28.11 - 2025-04-28 =

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Billplz for WooCommerce ===
 Contributors: wanzulnet, yiedpozi
 Tags: billplz
-Tested up to: 6.8
-Stable tag: 3.28.11
+Tested up to: 6.8.1
+Stable tag: 3.28.12
 Requires at least: 4.6
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -22,6 +22,9 @@ Install this plugin to accept payment using Billplz.
 * Enable X Signature Key at Billplz Account Settings
 
 == Changelog ==
+
+= 3.28.12 - 2025-05-xx =
+* ADDED: Enable/disable automatic bill deletion upon order marked as "Cancelled"
 
 = 3.28.11 - 2025-04-28 =
 * FIXED: Removed "IC Number" field from refund form


### PR DESCRIPTION
### Changes proposed in this Pull Request:
- Automatically delete bill when order marked as `Cancelled` (if feature enabled in the plugin settings)