### PR TITLE
Fix: Unable to Find an Order Due to Missing Bill ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Accept payment using Billplz.
 Compatible up to:
-- PHP 8.3
-- WordPress 6.8.3
-- WooCommerce 10.3.5
+- PHP 8.4
+- WordPress 6.9
+- WooCommerce 10.7
 
 # Installation
 

--- a/billplzWoo.php
+++ b/billplzWoo.php
@@ -6,7 +6,7 @@
  * Description: Billplz. Fair payment platform.
  * Author: Billplz Sdn Bhd
  * Author URI: http://github.com/billplz/billplz-for-woocommerce
- * Version: 3.28.13
+ * Version: 3.28.14
  * Requires PHP: 7.0
  * Requires at least: 4.6
  * Requires Plugins: woocommerce
@@ -52,7 +52,7 @@ class Woocommerce_Billplz {
     $this->define( 'BFW_PLUGIN_URL', plugin_dir_url(BFW_PLUGIN_FILE));
     $this->define( 'BFW_PLUGIN_DIR',  dirname(BFW_PLUGIN_FILE) );
     $this->define( 'BFW_BASENAME',  plugin_basename(BFW_PLUGIN_FILE) );
-    $this->define( 'BFW_PLUGIN_VER',  '3.28.13' );
+    $this->define( 'BFW_PLUGIN_VER',  '3.28.14' );
   }
 
   public function check_environment() {

--- a/includes/wc_billplz_gateway.php
+++ b/includes/wc_billplz_gateway.php
@@ -1297,7 +1297,6 @@ class WC_Billplz_Gateway extends WC_Payment_Gateway
       if (!empty(bfw_get_bill_state_legacy($order_id, $bill_id))){
         self::log("Deleting bill ({$bill_id}) for order number #{$order_id}");
 
-        bfw_delete_bill($bill_id);
         list($rheader, $rbody) = $billplz->toArray($billplz->deleteBill($bill_id));
 
         if ($rheader === 200) {

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Billplz for WooCommerce ===
 Contributors: wanzulnet, yiedpozi
 Tags: billplz
-Tested up to: 6.8.3
-Stable tag: 3.28.13
+Tested up to: 6.9
+Stable tag: 3.28.14
 Requires at least: 4.6
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -22,6 +22,9 @@ Install this plugin to accept payment using Billplz.
 * Enable X Signature Key at Billplz Account Settings
 
 == Changelog ==
+
+= 3.28.14 - 2026-04-15 =
+* FIXED: Order payment status not updated when a deleted bill later received a successful payment
 
 = 3.28.13 - 2025-07-28 =
 * FIXED: X-Signature mismatch caused by special character encoding in the payment callback data (e.g., slash)


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Avoid deleting bill ID on WooCommerce order data when deleting a bill upon order cancelled.

In some cases, a deleted bill may still be marked as paid if a payment succeeds after the bill has already been deleted. If the bill ID is removed from the WooCommerce order, our plugin will no longer be able to locate the order associated with that bill. As a result, the order cannot be updated to paid when the successful payment notification is received.